### PR TITLE
Remove old workflows and reuse new ones: Backport, Comment Commands and Tag

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,24 +11,5 @@ on:
   # See also commands.yml for the /backport triggered variant of this workflow.
 
 jobs:
-  # NOTE(negz): I tested many backport GitHub actions before landing on this
-  # one. Many do not support merge commits, or do not support pull requests with
-  # more than one commit. This one does. It also handily links backport PRs with
-  # new PRs, and provides commentary and instructions when it can't backport.
-  # The main gotchas with this action are that it _only_ supports merge commits,
-  # and that PRs _must_ be labelled before they're merged to trigger a backport.
-  open-pr:
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Open Backport PR
-        uses: zeebe-io/backport-action@v0.0.8
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_workspace: ${{ github.workspace }}
-          version: v0.0.8
+  backport:
+    uses: upbound/uptest/.github/workflows/provider-backport.yml@main

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -3,29 +3,5 @@ name: Comment Commands
 on: issue_comment
 
 jobs:
-  backport:
-    runs-on: ubuntu-22.04
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
-    steps:
-    - name: Extract Command
-      id: command
-      uses: xt0rted/slash-command-action@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        command: backport
-        reaction: "true"
-        reaction-type: "eyes"
-        allow-edits: "false"
-        permission-level: write
-
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Open Backport PR
-      uses: zeebe-io/backport-action@v0.0.4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        github_workspace: ${{ github.workspace }}
-        version: v0.0.4
+  comment-commands:
+    uses: upbound/uptest/.github/workflows/provider-commands.yml@main

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,7 +1,7 @@
 name: Tag
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: 
     inputs:
       version:
         description: 'Release version (e.g. v0.1.0)'
@@ -11,16 +11,8 @@ on:
         required: true
 
 jobs:
-  create-tag:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Create Tag
-        uses: negz/create-tag@v1
-        with:
-          version: ${{ github.event.inputs.version }}
-          message: ${{ github.event.inputs.message }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+  tag:
+    uses: upbound/uptest/.github/workflows/provider-tag.yml@main
+    with:
+      version: ${{ github.event.inputs.version }}
+      message: ${{ github.event.inputs.message }}


### PR DESCRIPTION
### Description of your changes

The following workflows have been updated:
- `backport.yml`
- `commands.yml`
- `tag.yml`

Consumes reusable workflows introduced in https://github.com/upbound/uptest/pull/74

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest`, `turkenf/provider-aws` and `turkenf/azuread`
