### PR TITLE
Inherit golangci-lint version from `build` submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,10 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_REQUIRED_VERSION ?= 1.19
-GOLANGCILINT_VERSION ?= 1.50.0
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.54.0
+
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis


### PR DESCRIPTION

<!--
Thank you for helping to improve Official Azuread Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azuread Provider pull request. Find us in https://crossplane.slack.com/archives/C01TRKD4623 if
you need any help contributing.
-->

### Description of your changes

* Motivation: golangci-lint base run was freezing on Mac M1 and go1.20.5.
* Remove the version override in the Makefile with the comment and consume the latest version from the build
* Presumably, it was a fix around consume a lot of memory on go1.20rc3 consume a lot of memory on go1.20rc3 golangci/golangci-lint#3470 helped in the latest golangci-lint release
* Update build submodule to consume upbound/build#238


I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

```
rm -rf .cache
 make lint
15:36:15 [ .. ] verify go modules dependencies have expected content
all modules verified
15:36:15 [ OK ] go modules dependencies verified
15:36:15 [WARN] the source directory is not relative to the GOPATH at /Users/xnull/go or you are you using symlinks. The build might run into issue. Please move the source directory to be at /Users/xnull/go/src/github.com/upbound/provider-azuread
15:36:15 [ .. ] installing golangci-lint-v1.54.0 darwin-arm64
15:36:16 [ OK ] installing golangci-lint-v1.54.0 darwin-arm64
15:36:16 [ .. ] golangci-lint
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive.
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
15:36:36 [ OK ] golangci-lint
```
