### PR TITLE
Bump uptest to v0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ GO_SUBDIRS += cmd internal apis
 KIND_VERSION = v0.15.0
 UP_VERSION = v0.16.1
 UP_CHANNEL = stable
-UPTEST_VERSION = v0.5.0
+UPTEST_VERSION = v0.7.0
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -201,7 +201,7 @@ crddiff: $(UPTEST)
 			continue ; \
 		fi ; \
 		echo "Checking $${crd} for breaking API changes..." ; \
-		changes_detected=$$($(UPTEST) crddiff revision <(git cat-file -p "$${GITHUB_BASE_REF}:$${crd}") "$${crd}" 2>&1) ; \
+		changes_detected=$$($(UPTEST) crddiff revision --enable-upjet-extensions <(git cat-file -p "$${GITHUB_BASE_REF}:$${crd}") "$${crd}" 2>&1) ; \
 		if [[ $$? != 0 ]] ; then \
 			printf "\033[31m"; echo "Breaking change detected!"; printf "\033[0m" ; \
 			echo "$${changes_detected}" ; \


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azuread Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azuread Provider pull request. Find us in https://crossplane.slack.com/archives/C01TRKD4623 if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azuread Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We would like to utilize the new `--enable-upjet-extensions` command-line option for the `crddiff revision` command. This enables breaking API changes introduced via upjet-generated CEL validation rules.



I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
