### PR TITLE
add basic plumbing for provider startup checks

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/upbound/provider-azuread/apis/v1alpha1"
 	"github.com/upbound/provider-azuread/config"
 	resolverapis "github.com/upbound/provider-azuread/internal/apis"
+	"github.com/upbound/provider-azuread/internal/bootcheck"
 	"github.com/upbound/provider-azuread/internal/clients"
 	"github.com/upbound/provider-azuread/internal/controller"
 	"github.com/upbound/provider-azuread/internal/features"
@@ -49,6 +50,13 @@ const (
 	certsDirEnvVar          = "CERTS_DIR"
 	tlsServerCertDir        = "/tls/server"
 )
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
+	}
+}
 
 func main() {
 	var (

--- a/internal/bootcheck/default.go
+++ b/internal/bootcheck/default.go
@@ -1,0 +1,10 @@
+//go:build !custombootcheck
+// +build !custombootcheck
+
+package bootcheck
+
+func CheckEnv() error {
+	// No-op by default. Use build tags for build-time isolation of custom preflight checks.
+	// Ensure to update the build tags on L1-L2 so that they are mutually exclusive across implementations.
+	return nil
+}


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

This PR proposes a simple approach to enable custom startup checks on the provider. As a concrete example, users may run their workloads in highly regulated environments where the provider should not start if the environment is not properly configured.

This implements the default path, which is a no-op. It uses a combination of an init() hook and [go build tags](https://pkg.go.dev/go/build#hdr-Build_Constraints) to:

- minimize code branching (build-time isolation)
- ensure critical checks run before anything else (fail fast)
- not require access to additional flags, env, or setup

Users can implement an array of preflight checks as separate files in this repository or a fork, and supply GO_TAGS=<..> to build an image with a specific one.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Local xpkgs with build tags.

[contribution process]: https://git.io/fj2m9
