### PR TITLE
Fix converted singleton lists in the generated example manifests

### DIFF
--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/examples/conversion"
 	"github.com/crossplane/upjet/v2/pkg/pipeline"
 	"github.com/hashicorp/terraform-provider-azuread/xpprovider"
 
@@ -42,7 +43,11 @@ func main() {
 	kingpin.FatalIfError(err, "Cannot initialize the cluster-scoped provider configuration")
 	dumpGeneratedResourceList(pc, generatedResourceList)
 	dumpSkippedResourcesCSV(pc, skippedResourcesCSV)
+
 	pipeline.Run(pc, pns, absRootDir)
+
+	kingpin.FatalIfError(conversion.ApplyAPIConverters(pc, "../examples-generated/cluster", "../hack/boilerplate.yaml.txt"), "Cannot convert singleton lists to embedded objects in example cluster-scoped resource manifests.")
+	kingpin.FatalIfError(conversion.ApplyAPIConverters(pns, "../examples-generated/namespaced", "../hack/boilerplate.yaml.txt"), "Cannot convert singleton lists to embedded objects in example namespace-scoped resource manifests.")
 }
 
 func dumpGeneratedResourceList(p *ujconfig.Provider, targetPath *string) {

--- a/examples-generated/cluster/administrativeunits/v1beta1/member.yaml
+++ b/examples-generated/cluster/administrativeunits/v1beta1/member.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: administrativeunits.azuread.upbound.io/v1beta1
 kind: Member
 metadata:

--- a/examples-generated/cluster/administrativeunits/v1beta1/unit.yaml
+++ b/examples-generated/cluster/administrativeunits/v1beta1/unit.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: administrativeunits.azuread.upbound.io/v1beta1
 kind: Unit
 metadata:

--- a/examples-generated/cluster/app/v1beta1/roleassignment.yaml
+++ b/examples-generated/cluster/app/v1beta1/roleassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: app.azuread.upbound.io/v1beta1
 kind: RoleAssignment
 metadata:

--- a/examples-generated/cluster/applications/v1beta1/approle.yaml
+++ b/examples-generated/cluster/applications/v1beta1/approle.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta1
 kind: AppRole
 metadata:

--- a/examples-generated/cluster/applications/v1beta1/certificate.yaml
+++ b/examples-generated/cluster/applications/v1beta1/certificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta1
 kind: Certificate
 metadata:

--- a/examples-generated/cluster/applications/v1beta1/federatedidentitycredential.yaml
+++ b/examples-generated/cluster/applications/v1beta1/federatedidentitycredential.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta1
 kind: FederatedIdentityCredential
 metadata:

--- a/examples-generated/cluster/applications/v1beta1/password.yaml
+++ b/examples-generated/cluster/applications/v1beta1/password.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta1
 kind: Password
 metadata:

--- a/examples-generated/cluster/applications/v1beta1/preauthorized.yaml
+++ b/examples-generated/cluster/applications/v1beta1/preauthorized.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta1
 kind: PreAuthorized
 metadata:
@@ -31,7 +35,7 @@ metadata:
 spec:
   forProvider:
     api:
-    - oauth2PermissionScope:
+      oauth2PermissionScope:
       - adminConsentDescription: Administer the application
         adminConsentDisplayName: Administer
         enabled: true

--- a/examples-generated/cluster/applications/v1beta2/application.yaml
+++ b/examples-generated/cluster/applications/v1beta2/application.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.upbound.io/v1beta2
 kind: Application
 metadata:
@@ -9,7 +13,7 @@ metadata:
 spec:
   forProvider:
     api:
-    - knownClientApplicationsRefs:
+      knownClientApplicationsRefs:
       - name: known1
       - name: known2
       mappedClaimsEnabled: true
@@ -54,7 +58,7 @@ spec:
     - api://example-app
     logoImage: ${filebase64("/path/to/logo.png")}
     optionalClaims:
-    - accessToken:
+      accessToken:
       - name: myclaim
       - name: otherclaim
       idToken:
@@ -80,9 +84,9 @@ spec:
       resourceAppId: c5393580-f805-4401-95e8-94b7a6ef2fc2
     signInAudience: AzureADMultipleOrgs
     web:
-    - homepageUrl: https://app.example.net
+      homepageUrl: https://app.example.net
       implicitGrant:
-      - accessTokenIssuanceEnabled: true
+        accessTokenIssuanceEnabled: true
         idTokenIssuanceEnabled: true
       logoutUrl: https://app.example.net/logout
       redirectUris:

--- a/examples-generated/cluster/conditionalaccess/v1beta2/accesspolicy.yaml
+++ b/examples-generated/cluster/conditionalaccess/v1beta2/accesspolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: conditionalaccess.azuread.upbound.io/v1beta2
 kind: AccessPolicy
 metadata:
@@ -9,23 +13,23 @@ metadata:
 spec:
   forProvider:
     conditions:
-    - applications:
-      - excludedApplications: []
+      applications:
+        excludedApplications: []
         includedApplications:
         - All
       clientAppTypes:
       - all
       devices:
-      - filter:
-        - mode: exclude
+        filter:
+          mode: exclude
           rule: device.operatingSystem eq "Doors"
       locations:
-      - excludedLocations:
+        excludedLocations:
         - AllTrusted
         includedLocations:
         - All
       platforms:
-      - excludedPlatforms:
+        excludedPlatforms:
         - iOS
         includedPlatforms:
         - android
@@ -34,17 +38,17 @@ spec:
       userRiskLevels:
       - medium
       users:
-      - excludedUsers:
+        excludedUsers:
         - GuestsOrExternalUsers
         includedUsers:
         - All
     displayName: example policy
     grantControls:
-    - builtInControls:
+      builtInControls:
       - mfa
       operator: OR
     sessionControls:
-    - applicationEnforcedRestrictionsEnabled: true
+      applicationEnforcedRestrictionsEnabled: true
       cloudAppSecurityPolicy: monitorOnly
       disableResilienceDefaults: false
       signInFrequency: 10

--- a/examples-generated/cluster/conditionalaccess/v1beta2/location.yaml
+++ b/examples-generated/cluster/conditionalaccess/v1beta2/location.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: conditionalaccess.azuread.upbound.io/v1beta2
 kind: Location
 metadata:
@@ -10,7 +14,7 @@ spec:
   forProvider:
     displayName: IP Named Location
     ip:
-    - ipRanges:
+      ipRanges:
       - 1.1.1.1/32
       - 2.2.2.2/32
       trusted: true

--- a/examples-generated/cluster/directoryroles/v1beta1/customdirectoryrole.yaml
+++ b/examples-generated/cluster/directoryroles/v1beta1/customdirectoryrole.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.upbound.io/v1beta1
 kind: CustomDirectoryRole
 metadata:

--- a/examples-generated/cluster/directoryroles/v1beta1/role.yaml
+++ b/examples-generated/cluster/directoryroles/v1beta1/role.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.upbound.io/v1beta1
 kind: Role
 metadata:

--- a/examples-generated/cluster/directoryroles/v1beta1/roleassignment.yaml
+++ b/examples-generated/cluster/directoryroles/v1beta1/roleassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.upbound.io/v1beta1
 kind: RoleAssignment
 metadata:

--- a/examples-generated/cluster/directoryroles/v1beta1/roleeligibilityschedulerequest.yaml
+++ b/examples-generated/cluster/directoryroles/v1beta1/roleeligibilityschedulerequest.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.upbound.io/v1beta1
 kind: RoleEligibilityScheduleRequest
 metadata:

--- a/examples-generated/cluster/groups/v1beta1/member.yaml
+++ b/examples-generated/cluster/groups/v1beta1/member.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: groups.azuread.upbound.io/v1beta1
 kind: Member
 metadata:

--- a/examples-generated/cluster/groups/v1beta2/group.yaml
+++ b/examples-generated/cluster/groups/v1beta2/group.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: groups.azuread.upbound.io/v1beta2
 kind: Group
 metadata:

--- a/examples-generated/cluster/identitygovernance/v1beta1/privilegedaccessgroupassignmentschedule.yaml
+++ b/examples-generated/cluster/identitygovernance/v1beta1/privilegedaccessgroupassignmentschedule.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: identitygovernance.azuread.upbound.io/v1beta1
 kind: PrivilegedAccessGroupAssignmentSchedule
 metadata:

--- a/examples-generated/cluster/identitygovernance/v1beta1/privilegedaccessgroupeligibilityschedule.yaml
+++ b/examples-generated/cluster/identitygovernance/v1beta1/privilegedaccessgroupeligibilityschedule.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: identitygovernance.azuread.upbound.io/v1beta1
 kind: PrivilegedAccessGroupEligibilitySchedule
 metadata:

--- a/examples-generated/cluster/invitations/v1beta2/invitation.yaml
+++ b/examples-generated/cluster/invitations/v1beta2/invitation.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: invitations.azuread.upbound.io/v1beta2
 kind: Invitation
 metadata:

--- a/examples-generated/cluster/policies/v1beta1/claimsmappingpolicy.yaml
+++ b/examples-generated/cluster/policies/v1beta1/claimsmappingpolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: policies.azuread.upbound.io/v1beta1
 kind: ClaimsMappingPolicy
 metadata:

--- a/examples-generated/cluster/policies/v1beta1/grouprolemanagementpolicy.yaml
+++ b/examples-generated/cluster/policies/v1beta1/grouprolemanagementpolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: policies.azuread.upbound.io/v1beta1
 kind: GroupRoleManagementPolicy
 metadata:
@@ -9,16 +13,16 @@ metadata:
 spec:
   forProvider:
     activeAssignmentRules:
-    - expireAfter: P365D
+      expireAfter: P365D
     eligibleAssignmentRules:
-    - expirationRequired: false
+      expirationRequired: false
     groupIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
     notificationRules:
-    - eligibleAssignments:
-      - approverNotifications:
-        - additionalRecipients:
+      eligibleAssignments:
+        approverNotifications:
+          additionalRecipients:
           - someone@example.com
           - someone.else@example.com
           defaultRecipients: false

--- a/examples-generated/cluster/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
+++ b/examples-generated/cluster/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipaldelegated.azuread.upbound.io/v1beta1
 kind: PermissionGrant
 metadata:

--- a/examples-generated/cluster/serviceprincipals/v1beta1/certificate.yaml
+++ b/examples-generated/cluster/serviceprincipals/v1beta1/certificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta1
 kind: Certificate
 metadata:

--- a/examples-generated/cluster/serviceprincipals/v1beta1/claimsmappingpolicyassignment.yaml
+++ b/examples-generated/cluster/serviceprincipals/v1beta1/claimsmappingpolicyassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta1
 kind: ClaimsMappingPolicyAssignment
 metadata:

--- a/examples-generated/cluster/serviceprincipals/v1beta1/password.yaml
+++ b/examples-generated/cluster/serviceprincipals/v1beta1/password.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta1
 kind: Password
 metadata:

--- a/examples-generated/cluster/serviceprincipals/v1beta1/tokensigningcertificate.yaml
+++ b/examples-generated/cluster/serviceprincipals/v1beta1/tokensigningcertificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta1
 kind: TokenSigningCertificate
 metadata:

--- a/examples-generated/cluster/serviceprincipals/v1beta2/principal.yaml
+++ b/examples-generated/cluster/serviceprincipals/v1beta2/principal.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta2
 kind: Principal
 metadata:

--- a/examples-generated/cluster/synchronization/v1beta1/job.yaml
+++ b/examples-generated/cluster/synchronization/v1beta1/job.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: synchronization.azuread.upbound.io/v1beta1
 kind: Job
 metadata:

--- a/examples-generated/cluster/synchronization/v1beta1/secret.yaml
+++ b/examples-generated/cluster/synchronization/v1beta1/secret.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: synchronization.azuread.upbound.io/v1beta1
 kind: Secret
 metadata:

--- a/examples-generated/cluster/users/v1beta1/user.yaml
+++ b/examples-generated/cluster/users/v1beta1/user.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: users.azuread.upbound.io/v1beta1
 kind: User
 metadata:

--- a/examples-generated/namespaced/administrativeunits/v1beta1/member.yaml
+++ b/examples-generated/namespaced/administrativeunits/v1beta1/member.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: administrativeunits.azuread.m.upbound.io/v1beta1
 kind: Member
 metadata:

--- a/examples-generated/namespaced/administrativeunits/v1beta1/unit.yaml
+++ b/examples-generated/namespaced/administrativeunits/v1beta1/unit.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: administrativeunits.azuread.m.upbound.io/v1beta1
 kind: Unit
 metadata:

--- a/examples-generated/namespaced/app/v1beta1/roleassignment.yaml
+++ b/examples-generated/namespaced/app/v1beta1/roleassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: app.azuread.m.upbound.io/v1beta1
 kind: RoleAssignment
 metadata:

--- a/examples-generated/namespaced/applications/v1beta1/application.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/application.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: Application
 metadata:
@@ -10,7 +14,7 @@ metadata:
 spec:
   forProvider:
     api:
-    - knownClientApplicationsRefs:
+      knownClientApplicationsRefs:
       - name: known1
       - name: known2
       mappedClaimsEnabled: true
@@ -55,7 +59,7 @@ spec:
     - api://example-app
     logoImage: ${filebase64("/path/to/logo.png")}
     optionalClaims:
-    - accessToken:
+      accessToken:
       - name: myclaim
       - name: otherclaim
       idToken:
@@ -81,9 +85,9 @@ spec:
       resourceAppId: c5393580-f805-4401-95e8-94b7a6ef2fc2
     signInAudience: AzureADMultipleOrgs
     web:
-    - homepageUrl: https://app.example.net
+      homepageUrl: https://app.example.net
       implicitGrant:
-      - accessTokenIssuanceEnabled: true
+        accessTokenIssuanceEnabled: true
         idTokenIssuanceEnabled: true
       logoutUrl: https://app.example.net/logout
       redirectUris:

--- a/examples-generated/namespaced/applications/v1beta1/approle.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/approle.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: AppRole
 metadata:

--- a/examples-generated/namespaced/applications/v1beta1/certificate.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/certificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: Certificate
 metadata:

--- a/examples-generated/namespaced/applications/v1beta1/federatedidentitycredential.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/federatedidentitycredential.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: FederatedIdentityCredential
 metadata:

--- a/examples-generated/namespaced/applications/v1beta1/password.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/password.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: Password
 metadata:

--- a/examples-generated/namespaced/applications/v1beta1/preauthorized.yaml
+++ b/examples-generated/namespaced/applications/v1beta1/preauthorized.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: applications.azuread.m.upbound.io/v1beta1
 kind: PreAuthorized
 metadata:
@@ -33,7 +37,7 @@ metadata:
 spec:
   forProvider:
     api:
-    - oauth2PermissionScope:
+      oauth2PermissionScope:
       - adminConsentDescription: Administer the application
         adminConsentDisplayName: Administer
         enabled: true

--- a/examples-generated/namespaced/conditionalaccess/v1beta1/accesspolicy.yaml
+++ b/examples-generated/namespaced/conditionalaccess/v1beta1/accesspolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: conditionalaccess.azuread.m.upbound.io/v1beta1
 kind: AccessPolicy
 metadata:
@@ -10,23 +14,23 @@ metadata:
 spec:
   forProvider:
     conditions:
-    - applications:
-      - excludedApplications: []
+      applications:
+        excludedApplications: []
         includedApplications:
         - All
       clientAppTypes:
       - all
       devices:
-      - filter:
-        - mode: exclude
+        filter:
+          mode: exclude
           rule: device.operatingSystem eq "Doors"
       locations:
-      - excludedLocations:
+        excludedLocations:
         - AllTrusted
         includedLocations:
         - All
       platforms:
-      - excludedPlatforms:
+        excludedPlatforms:
         - iOS
         includedPlatforms:
         - android
@@ -35,17 +39,17 @@ spec:
       userRiskLevels:
       - medium
       users:
-      - excludedUsers:
+        excludedUsers:
         - GuestsOrExternalUsers
         includedUsers:
         - All
     displayName: example policy
     grantControls:
-    - builtInControls:
+      builtInControls:
       - mfa
       operator: OR
     sessionControls:
-    - applicationEnforcedRestrictionsEnabled: true
+      applicationEnforcedRestrictionsEnabled: true
       cloudAppSecurityPolicy: monitorOnly
       disableResilienceDefaults: false
       signInFrequency: 10

--- a/examples-generated/namespaced/conditionalaccess/v1beta1/location.yaml
+++ b/examples-generated/namespaced/conditionalaccess/v1beta1/location.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: conditionalaccess.azuread.m.upbound.io/v1beta1
 kind: Location
 metadata:
@@ -11,7 +15,7 @@ spec:
   forProvider:
     displayName: IP Named Location
     ip:
-    - ipRanges:
+      ipRanges:
       - 1.1.1.1/32
       - 2.2.2.2/32
       trusted: true

--- a/examples-generated/namespaced/directoryroles/v1beta1/customdirectoryrole.yaml
+++ b/examples-generated/namespaced/directoryroles/v1beta1/customdirectoryrole.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.m.upbound.io/v1beta1
 kind: CustomDirectoryRole
 metadata:

--- a/examples-generated/namespaced/directoryroles/v1beta1/role.yaml
+++ b/examples-generated/namespaced/directoryroles/v1beta1/role.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.m.upbound.io/v1beta1
 kind: Role
 metadata:

--- a/examples-generated/namespaced/directoryroles/v1beta1/roleassignment.yaml
+++ b/examples-generated/namespaced/directoryroles/v1beta1/roleassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.m.upbound.io/v1beta1
 kind: RoleAssignment
 metadata:

--- a/examples-generated/namespaced/directoryroles/v1beta1/roleeligibilityschedulerequest.yaml
+++ b/examples-generated/namespaced/directoryroles/v1beta1/roleeligibilityschedulerequest.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: directoryroles.azuread.m.upbound.io/v1beta1
 kind: RoleEligibilityScheduleRequest
 metadata:

--- a/examples-generated/namespaced/groups/v1beta1/group.yaml
+++ b/examples-generated/namespaced/groups/v1beta1/group.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: groups.azuread.m.upbound.io/v1beta1
 kind: Group
 metadata:

--- a/examples-generated/namespaced/groups/v1beta1/member.yaml
+++ b/examples-generated/namespaced/groups/v1beta1/member.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: groups.azuread.m.upbound.io/v1beta1
 kind: Member
 metadata:

--- a/examples-generated/namespaced/identitygovernance/v1beta1/privilegedaccessgroupassignmentschedule.yaml
+++ b/examples-generated/namespaced/identitygovernance/v1beta1/privilegedaccessgroupassignmentschedule.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: identitygovernance.azuread.m.upbound.io/v1beta1
 kind: PrivilegedAccessGroupAssignmentSchedule
 metadata:

--- a/examples-generated/namespaced/identitygovernance/v1beta1/privilegedaccessgroupeligibilityschedule.yaml
+++ b/examples-generated/namespaced/identitygovernance/v1beta1/privilegedaccessgroupeligibilityschedule.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: identitygovernance.azuread.m.upbound.io/v1beta1
 kind: PrivilegedAccessGroupEligibilitySchedule
 metadata:

--- a/examples-generated/namespaced/invitations/v1beta1/invitation.yaml
+++ b/examples-generated/namespaced/invitations/v1beta1/invitation.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: invitations.azuread.m.upbound.io/v1beta1
 kind: Invitation
 metadata:

--- a/examples-generated/namespaced/policies/v1beta1/claimsmappingpolicy.yaml
+++ b/examples-generated/namespaced/policies/v1beta1/claimsmappingpolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: policies.azuread.m.upbound.io/v1beta1
 kind: ClaimsMappingPolicy
 metadata:

--- a/examples-generated/namespaced/policies/v1beta1/grouprolemanagementpolicy.yaml
+++ b/examples-generated/namespaced/policies/v1beta1/grouprolemanagementpolicy.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: policies.azuread.m.upbound.io/v1beta1
 kind: GroupRoleManagementPolicy
 metadata:
@@ -10,16 +14,16 @@ metadata:
 spec:
   forProvider:
     activeAssignmentRules:
-    - expireAfter: P365D
+      expireAfter: P365D
     eligibleAssignmentRules:
-    - expirationRequired: false
+      expirationRequired: false
     groupIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
     notificationRules:
-    - eligibleAssignments:
-      - approverNotifications:
-        - additionalRecipients:
+      eligibleAssignments:
+        approverNotifications:
+          additionalRecipients:
           - someone@example.com
           - someone.else@example.com
           defaultRecipients: false

--- a/examples-generated/namespaced/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
+++ b/examples-generated/namespaced/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipaldelegated.azuread.m.upbound.io/v1beta1
 kind: PermissionGrant
 metadata:

--- a/examples-generated/namespaced/serviceprincipals/v1beta1/certificate.yaml
+++ b/examples-generated/namespaced/serviceprincipals/v1beta1/certificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.m.upbound.io/v1beta1
 kind: Certificate
 metadata:

--- a/examples-generated/namespaced/serviceprincipals/v1beta1/claimsmappingpolicyassignment.yaml
+++ b/examples-generated/namespaced/serviceprincipals/v1beta1/claimsmappingpolicyassignment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.m.upbound.io/v1beta1
 kind: ClaimsMappingPolicyAssignment
 metadata:

--- a/examples-generated/namespaced/serviceprincipals/v1beta1/password.yaml
+++ b/examples-generated/namespaced/serviceprincipals/v1beta1/password.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.m.upbound.io/v1beta1
 kind: Password
 metadata:

--- a/examples-generated/namespaced/serviceprincipals/v1beta1/principal.yaml
+++ b/examples-generated/namespaced/serviceprincipals/v1beta1/principal.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.m.upbound.io/v1beta1
 kind: Principal
 metadata:

--- a/examples-generated/namespaced/serviceprincipals/v1beta1/tokensigningcertificate.yaml
+++ b/examples-generated/namespaced/serviceprincipals/v1beta1/tokensigningcertificate.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: serviceprincipals.azuread.m.upbound.io/v1beta1
 kind: TokenSigningCertificate
 metadata:

--- a/examples-generated/namespaced/synchronization/v1beta1/job.yaml
+++ b/examples-generated/namespaced/synchronization/v1beta1/job.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: synchronization.azuread.m.upbound.io/v1beta1
 kind: Job
 metadata:

--- a/examples-generated/namespaced/synchronization/v1beta1/secret.yaml
+++ b/examples-generated/namespaced/synchronization/v1beta1/secret.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: synchronization.azuread.m.upbound.io/v1beta1
 kind: Secret
 metadata:

--- a/examples-generated/namespaced/users/v1beta1/user.yaml
+++ b/examples-generated/namespaced/users/v1beta1/user.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: users.azuread.m.upbound.io/v1beta1
 kind: User
 metadata:

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,16 @@
 
 module github.com/upbound/provider-azuread
 
-go 1.24.6
+go 1.24.7
+
+toolchain go1.24.9
 
 require (
 	dario.cat/mergo v1.0.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
-	github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8
+	github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-provider-azuread v1.6.1-0.20230727144955-0adfe586f500
@@ -99,7 +101,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 // indirect
+	github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181 h
 github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec h1:+51Et4UW8XrvGne8RAqn9qEIfhoqPXYqIp/kQvpMaAo=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8 h1:zdxlqcXtEhqb7YKsipQk4lIfLhp42UuJSAyFTw+LhAs=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8/go.mod h1:nXboF68y9ZQRu39kZirQQiPL/BA4Afic17rEdHE+VQo=
+github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a h1:Uz9iN9FE/sPKSX/z29krX/zMhHdjttvRnqgJPWwp+xU=
+github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
@@ -239,8 +239,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 h1:yBQlHXLeUJL3TWVmzup5uT3wG5FLxhiTAiTsmNVocys=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
+github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0 h1:05HUfXEb9O/nGF32uKsjjYeGJBZ6PeVHMeqetyXUgR8=
+github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=

--- a/hack/boilerplate.yaml.txt
+++ b/hack/boilerplate.yaml.txt
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Related PRs: https://github.com/crossplane/upjet/pull/538/files

This PR fixes the converted singleton lists in the generated example manifests. We now post process the generated example manifests for the latest versions of the resources by applying the API converters and adding license headers.

This PR also adds a license file, `hack/boilerplate.yaml.txt`, to be used for the generated example manifests.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Update upjet dependency when https://github.com/crossplane/upjet/pull/538 is merged.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
