### PR TITLE
Bump Go dependency github.com/crossplane/upjet/v2 to commit 8d73164bb9bd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
-	github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a
+	github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-provider-azuread v1.6.1-0.20230727144955-0adfe586f500

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181 h
 github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec h1:+51Et4UW8XrvGne8RAqn9qEIfhoqPXYqIp/kQvpMaAo=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a h1:Uz9iN9FE/sPKSX/z29krX/zMhHdjttvRnqgJPWwp+xU=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251016125717-bc4227e2dc7a/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
+github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd h1:XpqPbFdc46ZLdIHED+YYKu8hjCQ8Nme6u9Btd1R6rqE=
+github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=


### PR DESCRIPTION
### Description of your changes

Relevant PR: https://github.com/crossplane/upjet/pull/545

This PR bumps the `github.com/crossplane/upjet/v2` dependency to the latest main branch commit `8d73164bb9bd255e35d94643a8336029419056c4`.

This update includes a fix for a data race issue in the `conversion.Convert` function where multiple goroutines could simultaneously modify conversion paths during in-place sorting. The fix prevents potential concurrent modification problems by creating a copy of the conversion paths before sorting.

I have:
- [x] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested with `make reviewable` which includes:
- Code generation
- Linting with golangci-lint
- Unit tests