### PR TITLE
fix: bump upjet to 32190ad6e1bb

### DIFF
--- a/config/provider.go
+++ b/config/provider.go
@@ -177,7 +177,7 @@ func bumpVersionsWithEmbeddedLists(pc *ujconfig.Provider) {
 			r.SetCRDStorageVersion("v1beta1")
 			// because the controller reconciles on the API version with the singleton list API,
 			// no need for a Terraform conversion.
-			r.ControllerReconcileVersion = "v1beta1"
+			r.ControllerReconcileVersion = "v1beta1" //nolint:staticcheck
 			r.Conversions = []conversion.Conversion{
 				conversion.NewIdentityConversionExpandPaths(conversion.AllVersions, conversion.AllVersions, conversion.DefaultPathPrefixes(), r.CRDListConversionPaths()...),
 				conversion.NewSingletonListConversion("v1beta1", "v1beta2", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToEmbeddedObject),

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
-	github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd
+	github.com/crossplane/upjet/v2 v2.2.1-0.20260109091757-32190ad6e1bb
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-provider-azuread v1.6.1-0.20230727144955-0adfe586f500

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181 h
 github.com/crossplane/crossplane-runtime/v2 v2.0.0-20250730220209-c306b1c8b181/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec h1:+51Et4UW8XrvGne8RAqn9qEIfhoqPXYqIp/kQvpMaAo=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd h1:XpqPbFdc46ZLdIHED+YYKu8hjCQ8Nme6u9Btd1R6rqE=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251028081228-8d73164bb9bd/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260109091757-32190ad6e1bb h1:iYf42plpCgks+JaZGXYWoLoWvp9ktC69V/yJYrvry2I=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260109091757-32190ad6e1bb/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=


### PR DESCRIPTION
### Description of your changes

bump upjet dependency to https://github.com/crossplane/upjet/commit/32190ad6e1bb858bf68380773e038b5e23a9c5e7 
Consumes https://github.com/crossplane/upjet/pull/564

Fixes #287 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

tested manually with the following scenarios
https://github.com/crossplane/upjet/pull/564#issuecomment-3710554788
https://github.com/crossplane/upjet/pull/564#issuecomment-3719045862
[Uptest-examples/cluster/app/v1beta1/roleassignment.yaml](https://github.com/crossplane-contrib/provider-upjet-azuread/actions/runs/20966075465)

[contribution process]: https://git.io/fj2m9
