### PR TITLE
fix: add missing field backport membersRef and membersSelector in Group.groups/v1beta1

### DIFF
--- a/apis/cluster/groups/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/groups/v1beta1/zz_generated.deepcopy.go
@@ -203,6 +203,18 @@ func (in *GroupInitParameters) DeepCopyInto(out *GroupInitParameters) {
 			}
 		}
 	}
+	if in.MembersRefs != nil {
+		in, out := &in.MembersRefs, &out.MembersRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.MembersSelector != nil {
+		in, out := &in.MembersSelector, &out.MembersSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OnpremisesGroupType != nil {
 		in, out := &in.OnpremisesGroupType, &out.OnpremisesGroupType
 		*out = new(string)
@@ -616,6 +628,18 @@ func (in *GroupParameters) DeepCopyInto(out *GroupParameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.MembersRefs != nil {
+		in, out := &in.MembersRefs, &out.MembersRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.MembersSelector != nil {
+		in, out := &in.MembersSelector, &out.MembersSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.OnpremisesGroupType != nil {
 		in, out := &in.OnpremisesGroupType, &out.OnpremisesGroupType

--- a/apis/cluster/groups/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/groups/v1beta1/zz_generated.resolvers.go
@@ -15,6 +15,50 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ResolveReferences of this Group.
+func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
+	r := reference.NewAPIResolver(c, mg)
+
+	var mrsp reference.MultiResolutionResponse
+	var err error
+
+	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Members),
+		Extract:       resource.ExtractParamPath("object_id", true),
+		Namespace:     mg.GetNamespace(),
+		References:    mg.Spec.ForProvider.MembersRefs,
+		Selector:      mg.Spec.ForProvider.MembersSelector,
+		To: reference.To{
+			List:    &v1beta1.UserList{},
+			Managed: &v1beta1.User{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.Members")
+	}
+	mg.Spec.ForProvider.Members = reference.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.ForProvider.MembersRefs = mrsp.ResolvedReferences
+
+	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+		CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Members),
+		Extract:       resource.ExtractParamPath("object_id", true),
+		Namespace:     mg.GetNamespace(),
+		References:    mg.Spec.InitProvider.MembersRefs,
+		Selector:      mg.Spec.InitProvider.MembersSelector,
+		To: reference.To{
+			List:    &v1beta1.UserList{},
+			Managed: &v1beta1.User{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.Members")
+	}
+	mg.Spec.InitProvider.Members = reference.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.InitProvider.MembersRefs = mrsp.ResolvedReferences
+
+	return nil
+}
+
 // ResolveReferences of this Member.
 func (mg *Member) ResolveReferences(ctx context.Context, c client.Reader) error {
 	r := reference.NewAPIResolver(c, mg)

--- a/apis/cluster/groups/v1beta1/zz_group_types.go
+++ b/apis/cluster/groups/v1beta1/zz_group_types.go
@@ -99,8 +99,18 @@ type GroupInitParameters struct {
 
 	// A set of members who should be present in this group. Supported object types are Users, Groups or Service Principals. Cannot be used with the dynamic_membership block.
 	// A set of members who should be present in this group. Supported object types are Users, Groups or Service Principals
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/v2/apis/cluster/users/v1beta1.User
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +listType=set
 	Members []*string `json:"members,omitempty" tf:"members,omitempty"`
+
+	// References to User in users to populate members.
+	// +kubebuilder:validation:Optional
+	MembersRefs []v1.Reference `json:"membersRefs,omitempty" tf:"-"`
+
+	// Selector for a list of User in users to populate members.
+	// +kubebuilder:validation:Optional
+	MembersSelector *v1.Selector `json:"membersSelector,omitempty" tf:"-"`
 
 	// The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are UniversalDistributionGroup, UniversalMailEnabledSecurityGroup, or UniversalSecurityGroup.
 	// Indicates the target on-premise group type the group will be written back as
@@ -343,9 +353,19 @@ type GroupParameters struct {
 
 	// A set of members who should be present in this group. Supported object types are Users, Groups or Service Principals. Cannot be used with the dynamic_membership block.
 	// A set of members who should be present in this group. Supported object types are Users, Groups or Service Principals
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/v2/apis/cluster/users/v1beta1.User
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Members []*string `json:"members,omitempty" tf:"members,omitempty"`
+
+	// References to User in users to populate members.
+	// +kubebuilder:validation:Optional
+	MembersRefs []v1.Reference `json:"membersRefs,omitempty" tf:"-"`
+
+	// Selector for a list of User in users to populate members.
+	// +kubebuilder:validation:Optional
+	MembersSelector *v1.Selector `json:"membersSelector,omitempty" tf:"-"`
 
 	// The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are UniversalDistributionGroup, UniversalMailEnabledSecurityGroup, or UniversalSecurityGroup.
 	// Indicates the target on-premise group type the group will be written back as

--- a/package/crds/groups.azuread.upbound.io_groups.yaml
+++ b/package/crds/groups.azuread.upbound.io_groups.yaml
@@ -162,6 +162,84 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
+                  membersRefs:
+                    description: References to User in users to populate members.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: |-
+                                Resolution specifies whether resolution of this reference is required.
+                                The default is 'Required', which means the reconcile will fail if the
+                                reference cannot be resolved. 'Optional' means this reference will be
+                                a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: |-
+                                Resolve specifies when this reference should be resolved. The default
+                                is 'IfNotPresent', which will attempt to resolve the reference only when
+                                the corresponding field is not present. Use 'Always' to resolve the
+                                reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  membersSelector:
+                    description: Selector for a list of User in users to populate
+                      members.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   onpremisesGroupType:
                     description: |-
                       The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are UniversalDistributionGroup, UniversalMailEnabledSecurityGroup, or UniversalSecurityGroup.
@@ -316,6 +394,84 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: set
+                  membersRefs:
+                    description: References to User in users to populate members.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: |-
+                                Resolution specifies whether resolution of this reference is required.
+                                The default is 'Required', which means the reconcile will fail if the
+                                reference cannot be resolved. 'Optional' means this reference will be
+                                a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: |-
+                                Resolve specifies when this reference should be resolved. The default
+                                is 'IfNotPresent', which will attempt to resolve the reference only when
+                                the corresponding field is not present. Use 'Always' to resolve the
+                                reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  membersSelector:
+                    description: Selector for a list of User in users to populate
+                      members.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   onpremisesGroupType:
                     description: |-
                       The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are UniversalDistributionGroup, UniversalMailEnabledSecurityGroup, or UniversalSecurityGroup.


### PR DESCRIPTION
### Description of your changes

add missing field backport `membersRef` and `membersSelector` in v1beta1 of `Group.groups`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Uptest

[contribution process]: https://git.io/fj2m9
