### PR TITLE
testing: add API conversion roundtrip tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ GOLANGCILINT_VERSION ?= 2.12.2
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
-GO_SUBDIRS += cmd internal apis generate
+GO_SUBDIRS += cmd internal apis generate config
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/config/test/roundtrip/roundtrip_test.go
+++ b/config/test/roundtrip/roundtrip_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// package roundtrip contains API roundtrip tests
+// for multi-version managed resource APIs
+package roundtrip
+
+import (
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/apitesting/roundtrip"
+	"github.com/hashicorp/terraform-provider-azuread/xpprovider"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	clusterapis "github.com/upbound/provider-azuread/v2/apis/cluster"
+	namespacedapis "github.com/upbound/provider-azuread/v2/apis/namespaced"
+	"github.com/upbound/provider-azuread/v2/config"
+)
+
+// TestRoundTrip configures and invokes the API roundtrip tests.
+// For each registered API, a serialization roundtrip test and
+// conversion roundtrip test is invoked, with the given fuzzer
+// configurations.
+func TestRoundTrip(t *testing.T) {
+	// setup provider
+	schema, err := xpprovider.GetProviderSchema(t.Context())
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %s", err)
+	}
+	provider, err := config.GetProvider(t.Context(), schema, false)
+	if err != nil {
+		t.Fatalf("GetProvider: %s", err)
+	}
+	providerNamespaced, err := config.GetNamespacedProvider(t.Context(), schema, false)
+	if err != nil {
+		t.Fatalf("GetNamespacedProvider: %s", err)
+	}
+
+	testScheme := runtime.NewScheme()
+	if err := clusterapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("cluster-scoped apis AddToScheme: %s", err)
+	}
+	if err := namespacedapis.AddToScheme(testScheme); err != nil {
+		t.Fatalf("namespaced apis AddToScheme: %s", err)
+	}
+
+	rt, err := roundtrip.NewRoundTripTest(provider, providerNamespaced, testScheme,
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(10),
+			roundtrip.FuzzerNilChance(0)),
+		roundtrip.WithFuzzerConfig(
+			roundtrip.FuzzerIterations(30),
+			roundtrip.FuzzerNilChance(0.3)),
+		roundtrip.WithComparisonOptions(
+			roundtrip.EquateEmptyAndSingleZeroSlice(),
+			roundtrip.EquateNilAndZeroValuePtr(),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewRoundTripTest: %s", err)
+	}
+
+	t.Run("TestSerializationRoundtrip", func(t *testing.T) {
+		rt.TestSerializationRoundtrip(t)
+	})
+
+	t.Run("TestConversionRoundtrip", func(t *testing.T) {
+		rt.TestConversionRoundtrip(t)
+	})
+}


### PR DESCRIPTION
### Description of your changes

Adds API (conversion & serialization) roundtrip tests for multiversion MR APIs.
Integrates API roundtrip testing library at https://github.com/crossplane/upjet/pull/636, see the PR description for details on how it works.

The aim is to verify after conversions or serializations, the original resource is intact with no missing data 

First, prepares a `RoundtripTest` instance by supplying a test scheme with all APIs registered and configuring fuzzers
#### Serialization roundtrip:
For each API in the scheme, create a runtime instance by fuzzing API values, according to the given fuzzer
Then serialize and deserialize, compare the original vs roundtripped are equal

#### Conversion roundtrip:
- test library discovers all APIs that has multiple versions
- for each multi-version API, classifies hub and spoke versions
- Then, for each hub-spoke  pair, runs the following
  - start with hub, convert to spoke, convert back to hub, compare original vs roundtripped hub
  - start with spoke, convert to hub, convert back to spoke, compare original vs roundtripped spoke

#### Example:
`FooResource` API has 3 versions: `v1beta1`, `v1beta2`, `v1beta3` and `v1beta1` is the hub version, others being spoke. Following tests will run:

for v1beta1 - v1beta2 pair:
- `Hub v1beta1 -> Spoke v1beta2 -> Hub v1beta1`
- `Spoke v1beta2 -> Hub v1beta1 -> Spoke v1beta2`

for v1beta1-v1beta3 pair
- `Hub v1beta1 -> Spoke v1beta3 -> Hub v1beta1`
- `Spoke v1beta3 -> Hub v1beta1 -> Spoke v1beta2`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make test` & CI

[contribution process]: https://git.io/fj2m9
