### PR TITLE
Implement `upjet_resource_external_api_calls_total` metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.1
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2
 	github.com/hashicorp/terraform-provider-azuread v1.6.1-0.20230727144955-0adfe586f500
@@ -71,7 +72,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-azure-helpers v0.76.2 // indirect
@@ -184,4 +184,4 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.6.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-provider-azuread => github.com/upbound/terraform-provider-azuread v0.0.0-20260316080806-a4604dc8618a
+replace github.com/hashicorp/terraform-provider-azuread => github.com/upbound/terraform-provider-azuread v0.0.0-20260701132504-ccaa296b8da8

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uL
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/upbound/terraform-provider-azuread v0.0.0-20260316080806-a4604dc8618a h1:tw2e/2mG/8Qc0V15C/M4cSlHaHwyrz8xj3fFS7ZvGD4=
-github.com/upbound/terraform-provider-azuread v0.0.0-20260316080806-a4604dc8618a/go.mod h1:VTroVZDG7yZsE7CI8b6X8NGtll4vkDLC4zfL6UxiCWU=
+github.com/upbound/terraform-provider-azuread v0.0.0-20260701132504-ccaa296b8da8 h1:dgqc4wI5i4j+9wjD2BzehSA6odo9IfnMi0ozb2i2J7w=
+github.com/upbound/terraform-provider-azuread v0.0.0-20260701132504-ccaa296b8da8/go.mod h1:VTroVZDG7yZsE7CI8b6X8NGtll4vkDLC4zfL6UxiCWU=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b h1:3skJb1zt9rBR/4wUWMT32Ip02OckGzYyMhjCkEeCdfA=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b/go.mod h1:LaaCdCFepE8h8UtssvRbKBgrNUK4CKNh+bEyE0HnLvc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/clients/azuread.go
+++ b/internal/clients/azuread.go
@@ -7,6 +7,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -14,7 +15,9 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	upjetmetrics "github.com/crossplane/upjet/v2/pkg/metrics"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	tfazureclient "github.com/hashicorp/terraform-provider-azuread/xpprovider"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,6 +67,22 @@ var (
 	credentialsSourceUpbound                       xpv1.CredentialsSource = "Upbound"
 )
 
+// graphServiceFromPath extracts a short service label from a Microsoft Graph
+// API request path.
+//
+// Graph URL pattern: /{version}/{service}/...
+// Examples:
+//   - /v1.0/groups/abc-123      → "groups"
+//   - /beta/servicePrincipals   → "servicePrincipals"
+//   - /v1.0/directory/admin...  → "directory"
+func graphServiceFromPath(path string) string {
+	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 3)
+	if len(parts) >= 2 && parts[1] != "" {
+		return parts[1]
+	}
+	return "unknown"
+}
+
 // TerraformSetupBuilder returns Terraform setup with provider specific
 // configuration like provider credentials used to connect to cloud APIs in the
 // expected form of a Terraform provider.
@@ -106,6 +125,15 @@ func configureNoForkAzureClient(ctx context.Context, ps *terraform.Setup, p sche
 		return errors.Errorf("failed to configure the provider: %v", diag)
 	}
 	ps.Meta = p.Meta()
+	// RegisterResponseMiddleware will increment the `external_api_calls_total` metric multiple times if the request is retried e.g. as a result of HTTP 429
+	// It will NOT increment the metric if we do not receive a response back e.g. connection failure
+	tfazureclient.RegisterResponseMiddleware(ps.Meta, func(req *http.Request, resp *http.Response) (*http.Response, error) {
+		if req == nil || req.URL == nil || resp == nil {
+			return resp, nil
+		}
+		upjetmetrics.ExternalAPICalls.WithLabelValues(graphServiceFromPath(req.URL.Path), req.Method).Inc()
+		return resp, nil
+	})
 	return nil
 }
 

--- a/internal/clients/azuread_test.go
+++ b/internal/clients/azuread_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_graphServiceFromPath(t *testing.T) {
+	cases := map[string]struct {
+		path string
+		want string
+	}{
+		"v1_groups_collection": {
+			path: "/v1.0/groups",
+			want: "groups",
+		},
+		"v1_groups_item": {
+			path: "/v1.0/groups/abc-123",
+			want: "groups",
+		},
+		"not_valid_graph_path": {
+			path: "/some",
+			want: "unknown",
+		},
+		"empty_path": {
+			path: "",
+			want: "unknown",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := graphServiceFromPath(tc.path)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("graphServiceFromPath(%q) mismatch (-want +got):\n%s", tc.path, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes
I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested manually - example metric:
```shell
judasz@Jonaszs-MacBook-Pro provider-upjet-azuread % curl localhost:8080/metrics | rg upjet_resource_external_api_calls_total
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="DELETE",service="applications"} 1
upjet_resource_external_api_calls_total{operation="GET",service="applications"} 11
100  675k    0  675k    0     0  48.8M      0 --:--:-- --:--:-- --:--:-- 47.1M
```

[contribution process]: https://git.io/fj2m9
