### PR TITLE
renovate: fix and refactor configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,17 +10,17 @@
   "baseBranchPatterns": ["main"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
-  // By default renovate will auto detect whether semantic commits have been used
+  // By default, renovate will auto-detect whether semantic commits have been used
   // in the recent history and comply with that, we explicitly disable it
   "semanticCommits": "disabled",
   // All PRs should have a label
-  "labels": ["automated"],
+  "labels": ["automated", "renovate"],
   "customManagers": [
     {
       // We want a PR to bump Go versions used through env variables in any Github
       // Actions, taking it from the official Github repository.
       "customType": "regex",
-      "description": "Bump Go version in workflows",
+      "description": "Bump Go version in GH Action workflows",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"],
       "matchStrings": [
         "GO_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n"
@@ -35,9 +35,12 @@
       // any Github Actions, taking it from the official Github repository tags.
       "customType": "regex",
       "description": "Bump golangci-lint version in workflows",
-      "managerFilePatterns": ["/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"],
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/", "/^Makefile$/"],
       "matchStrings": [
-        "GOLANGCI_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n"
+        "GOLANGCI_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n",
+        "GOLANGCILINT_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n",
+        "GOLANGCILINT_VERSION \\??= (?<currentValue>.*?)\\n",
+        "GOLANGCI_VERSION \\??= (?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "golangci/golangci-lint"
@@ -49,34 +52,10 @@
       "description": "Bump Docker Buildx version in workflows",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"],
       "matchStrings": [
-        "DOCKER_BUILDX_VERSION: ['\"]?(?<currentValue>.*?)['\"]?'\\n"
+        "DOCKER_BUILDX_VERSION: ['\"]?(?<currentValue>.*?)['\"]?\\n"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "docker/buildx"
-    },
-    {
-      // We want a PR to bump golangci-lint versions used through make variables in
-      // the Makefile, taking it from the official Github repository releases.
-      "customType": "regex",
-      "description": "Bump golangci-lint version in the Makefile",
-      "managerFilePatterns": [
-        "/^Makefile$/",
-        "/^\\.github\\/workflows\\/[^/]+\\.ya?ml$/"
-      ],
-      "matchStrings": ["GOLANGCILINT_VERSION \\??= (?<currentValue>.*?)\\n"],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "golangci/golangci-lint",
-      "extractVersionTemplate": "^(?<version>.*)$"
-    },
-    {
-      // We want a PR to bump up CLI versions used through make variables in
-      // the Makefile, taking it from the official Github repository releases.
-      "customType": "regex",
-      "description": "Bump up CLI version in the Makefile",
-      "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": ["UP_VERSION \\??= (?<currentValue>.*?)\\n"],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "upbound/up"
     },
     {
       // We want a PR to bump uptest versions used through make variables in
@@ -106,8 +85,7 @@
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": ["CROSSPLANE_VERSION \\??= (?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "crossplane/crossplane",
-      "extractVersionTemplate": "^(?<version>.*)$"
+      "depNameTemplate": "crossplane/crossplane"
     },
     {
       // We want a PR to bump Crossplane CLI versions used through make variables in
@@ -115,7 +93,7 @@
       "customType": "regex",
       "description": "Bump Crossplane CLI version in the Makefile",
       "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": ["CROSSPLANE_CLI_VERSION ??= (?<currentValue>.*?)\\n"],
+      "matchStrings": ["CROSSPLANE_CLI_VERSION \\??= (?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "crossplane/crossplane"
     }
@@ -131,34 +109,73 @@
       "allowedVersions": "<1.0"
     },
     {
-      // We want a single PR for all the patches bumps of kubernetes related
+      // We want a single PR for all the patch bumps of kubernetes related
       // dependencies, as most of the time these are all strictly related.
       "matchDatasources": ["go"],
       "groupName": "kubernetes patches",
       "matchUpdateTypes": ["patch", "digest"],
-      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**"]
+      // Do not include k8s.io/utils and k8s.io/kube-openapi, they have no version tags
+      // let other k8s dependencies auto-manage them transitively
+      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**", "!k8s.io/utils{/,}**", "!k8s.io/kube-openapi{/,}**"],
     },
     {
       // We want dedicated PRs for each minor and major bumps to kubernetes related
       // dependencies.
       "matchDatasources": ["go"],
       "matchUpdateTypes": ["major", "minor"],
-      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**"]
+      "matchPackageNames": ["k8s.io{/,}**", "sigs.k8s.io{/,}**"],
+      // k8s library minor versions should typically follow
+      // crossplane-runtime for maximum compatibility.
+      // Let minor versions managed transitively and require
+      // dashboard approval.
+      "dependencyDashboardApproval": true,
     },
     {
-      // We want dedicated PRs for each bump to non-kubernetes Go dependencies, but
+      // Go XP dependencies separate major/minor/patch PRs
+      "description": "Separate PRs for major/minor/patch Crossplane Go dependencies",
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/crossplane{/,}**"],
+      "separateMultipleMinor": true,
+      "separateMinorPatch": true,
+      "separateMajorMinor": true,
+    },
+    {
+      // Allow Crossplane Go dependencies patch version bumps
+      "description": "Crossplane Go dependencies patch versions",
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["github.com/crossplane{/,}**"],
+    },
+    {
+      // Go XP dependencies major/minor/digest with dashboard approval
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["major", "minor", "digest"],
+      "matchPackageNames": ["github.com/crossplane{/,}**"],
+      "dependencyDashboardApproval": true,
+    },
+    {
+      // Explicitly disable k8s.io/utils and k8s.io/kube-openapi digest updates,
+      // they have no version tags, let other k8s dependencies auto-manage them
+      // transitively
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false,
+      "matchPackageNames": ["k8s.io/utils{/,}**", "k8s.io/kube-openapi{/,}**"]
+    },
+    {
+      // We want dedicated PRs for each bump to non-kubernetes and non-XP Go dependencies, but
       // only if there are known vulnerabilities in the current version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["*", "!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**", "!github.com/crossplane{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["major"]
     },
     {
-      // We want a single PR for all minor and patch bumps to non-kubernetes Go
+      // We want a single PR for all minor and patch bumps to non-kubernetes and non-XP Go
       // dependencies, but only if there are known vulnerabilities in the current
       // version.
       "matchDatasources": ["go"],
-      "matchPackageNames": ["*", "!k8s.io{/,}**", "!sigs.k8s.io{/,}**"],
+      "matchPackageNames": ["!k8s.io{/,}**", "!sigs.k8s.io{/,}**", "!github.com/crossplane{/,}**"],
       "enabled": false,
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "groupName": "all non-major go dependencies"
@@ -207,5 +224,5 @@
       "matchDepTypes": ["action"],
       "pinDigests": true
     }
-  ],
+  ]
 }


### PR DESCRIPTION
Mirror of https://github.com/crossplane-contrib/provider-upjet-azure/pull/1254

I have:

- [X] Read and followed Crossplane's [contribution process].
~~- [ ] Run `make reviewable` to ensure this PR is ready for review.~~

### How has this code been tested

```
renovate-config-validator --strict
```

[contribution process]: https://git.io/fj2m9
