### PR TITLE
Decouple conversion webhook registration from leader election

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -67,7 +67,7 @@ func init() {
 	}
 }
 
-func main() {
+func main() { //nolint:gocyclo // easier to follow as a unit
 	var (
 		app                     = kingpin.New(filepath.Base(os.Args[0]), "Terraform based Crossplane provider for Azuread").DefaultEnvars()
 		debug                   = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
@@ -195,7 +195,6 @@ func main() {
 		SetupFn:               clients.TerraformSetupBuilder(clusterProvider.TerraformProvider),
 		PollJitter:            pollJitter,
 		OperationTrackerStore: tjcontroller.NewOperationStore(logr),
-		StartWebhooks:         *certsDir != "",
 	}
 
 	namespacedOpts := tjcontroller.Options{
@@ -215,7 +214,6 @@ func main() {
 		SetupFn:               clients.TerraformSetupBuilder(namespacedProvider.TerraformProvider),
 		PollJitter:            pollJitter,
 		OperationTrackerStore: tjcontroller.NewOperationStore(logr),
-		StartWebhooks:         *certsDir != "",
 	}
 
 	if *enableManagementPolicies {
@@ -239,6 +237,15 @@ func main() {
 		}
 		clusterOpts.ChangeLogOptions = &clo
 		namespacedOpts.ChangeLogOptions = &clo
+	}
+
+	// Webhooks are registered eagerly on all pods before mgr.Start() so that
+	// every replica (leader and followers alike) can serve conversion requests.
+	// Reconciler setup is deferred to the gate and only runs on the leader.
+	startWebhooks := *certsDir != ""
+	if startWebhooks {
+		kingpin.FatalIfError(clustercontroller.SetupWebhookWithManager(mgr), "Cannot setup cluster-scoped webhooks")
+		kingpin.FatalIfError(namespacedcontroller.SetupWebhookWithManager(mgr), "Cannot setup namespaced webhooks")
 	}
 
 	canSafeStart, err := canWatchCRD(ctx, mgr)

--- a/config/templates/controller.go.tmpl
+++ b/config/templates/controller.go.tmpl
@@ -24,6 +24,15 @@ import (
 	{{ .Imports }}
 )
 
+// SetupWebhookWithManager registers the conversion webhook for {{ .CRD.Kind }}.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }}")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles {{ .CRD.Kind }} managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -127,14 +136,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }} if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind {{ .TypePackageAlias }}{{ .CRD.Kind }}")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.2.1
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
-	github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4
+	github.com/crossplane/upjet/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.2.1 h1:CJXV8+1SDXLYJx67sUO4MIuLCk
 github.com/crossplane/crossplane-runtime/v2 v2.2.1/go.mod h1:3Xq18YLf2en0BB2OZpcixTKazeX7bS3txLbQHjOR52c=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339 h1:MPbMxSlY+82UsjrLUAGyXlh/iX1tL5WNj8W9SOaq/nk=
 github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4 h1:ilL+vJYh88KscCt/VKIT+CiP/R82+KIvbkiuo5X0ceI=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
+github.com/crossplane/upjet/v2 v2.3.0 h1:esvhUnmSFqEDwJ8DqHoOXigd2B9qXZfqTrK3ZI0WkPY=
+github.com/crossplane/upjet/v2 v2.3.0/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=

--- a/internal/controller/cluster/administrativeunits/member/zz_controller.go
+++ b/internal/controller/cluster/administrativeunits/member/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Member.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Member managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Member if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/administrativeunits/unit/zz_controller.go
+++ b/internal/controller/cluster/administrativeunits/unit/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Unit.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Unit{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Unit")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Unit managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Unit if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Unit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Unit")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/app/roleassignment/zz_controller.go
+++ b/internal/controller/cluster/app/roleassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/application/zz_controller.go
+++ b/internal/controller/cluster/applications/application/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Application.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Application{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Application")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Application managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.Application if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Application{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Application")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/approle/zz_controller.go
+++ b/internal/controller/cluster/applications/approle/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for AppRole.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AppRole{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AppRole")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles AppRole managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.AppRole if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AppRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AppRole")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/certificate/zz_controller.go
+++ b/internal/controller/cluster/applications/certificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Certificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Certificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Certificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/federatedidentitycredential/zz_controller.go
+++ b/internal/controller/cluster/applications/federatedidentitycredential/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for FederatedIdentityCredential.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FederatedIdentityCredential{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FederatedIdentityCredential")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles FederatedIdentityCredential managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.FederatedIdentityCredential if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FederatedIdentityCredential{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FederatedIdentityCredential")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/flexiblefederatedidentitycredential/zz_controller.go
+++ b/internal/controller/cluster/applications/flexiblefederatedidentitycredential/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for FlexibleFederatedIdentityCredential.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FlexibleFederatedIdentityCredential{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FlexibleFederatedIdentityCredential")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles FlexibleFederatedIdentityCredential managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.FlexibleFederatedIdentityCredential if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FlexibleFederatedIdentityCredential{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FlexibleFederatedIdentityCredential")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/password/zz_controller.go
+++ b/internal/controller/cluster/applications/password/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Password.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Password managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Password if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/applications/preauthorized/zz_controller.go
+++ b/internal/controller/cluster/applications/preauthorized/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PreAuthorized.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PreAuthorized{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PreAuthorized")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PreAuthorized managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PreAuthorized if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PreAuthorized{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PreAuthorized")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/conditionalaccess/accesspolicy/zz_controller.go
+++ b/internal/controller/cluster/conditionalaccess/accesspolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for AccessPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.AccessPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.AccessPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles AccessPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.AccessPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.AccessPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.AccessPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/conditionalaccess/location/zz_controller.go
+++ b/internal/controller/cluster/conditionalaccess/location/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Location.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Location{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Location")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Location managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.Location if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Location{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Location")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/directoryroles/customdirectoryrole/zz_controller.go
+++ b/internal/controller/cluster/directoryroles/customdirectoryrole/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for CustomDirectoryRole.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.CustomDirectoryRole{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.CustomDirectoryRole")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles CustomDirectoryRole managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.CustomDirectoryRole if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.CustomDirectoryRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.CustomDirectoryRole")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/directoryroles/role/zz_controller.go
+++ b/internal/controller/cluster/directoryroles/role/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Role.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Role{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Role")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Role managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Role if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Role{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Role")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/directoryroles/roleassignment/zz_controller.go
+++ b/internal/controller/cluster/directoryroles/roleassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/directoryroles/roleeligibilityschedulerequest/zz_controller.go
+++ b/internal/controller/cluster/directoryroles/roleeligibilityschedulerequest/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleEligibilityScheduleRequest.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleEligibilityScheduleRequest{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleEligibilityScheduleRequest")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleEligibilityScheduleRequest managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleEligibilityScheduleRequest if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleEligibilityScheduleRequest{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleEligibilityScheduleRequest")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/groups/group/zz_controller.go
+++ b/internal/controller/cluster/groups/group/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Group.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Group{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Group")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Group managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.Group if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Group{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Group")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/groups/member/zz_controller.go
+++ b/internal/controller/cluster/groups/member/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Member.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Member managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Member if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/identitygovernance/privilegedaccessgroupassignmentschedule/zz_controller.go
+++ b/internal/controller/cluster/identitygovernance/privilegedaccessgroupassignmentschedule/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PrivilegedAccessGroupAssignmentSchedule.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupAssignmentSchedule{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PrivilegedAccessGroupAssignmentSchedule managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupAssignmentSchedule{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/identitygovernance/privilegedaccessgroupeligibilityschedule/zz_controller.go
+++ b/internal/controller/cluster/identitygovernance/privilegedaccessgroupeligibilityschedule/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PrivilegedAccessGroupEligibilitySchedule.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupEligibilitySchedule{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PrivilegedAccessGroupEligibilitySchedule managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupEligibilitySchedule{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/invitations/invitation/zz_controller.go
+++ b/internal/controller/cluster/invitations/invitation/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Invitation.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Invitation{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Invitation")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Invitation managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.Invitation if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Invitation{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Invitation")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/policies/claimsmappingpolicy/zz_controller.go
+++ b/internal/controller/cluster/policies/claimsmappingpolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for ClaimsMappingPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles ClaimsMappingPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.ClaimsMappingPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/policies/grouprolemanagementpolicy/zz_controller.go
+++ b/internal/controller/cluster/policies/grouprolemanagementpolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for GroupRoleManagementPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.GroupRoleManagementPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.GroupRoleManagementPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles GroupRoleManagementPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.GroupRoleManagementPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.GroupRoleManagementPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.GroupRoleManagementPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/providerconfig/config.go
+++ b/internal/controller/cluster/providerconfig/config.go
@@ -5,6 +5,7 @@
 package providerconfig
 
 import (
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -43,5 +44,14 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1beta1.ProviderConfigGroupVersionKind.String())
 		}
 	}, v1beta1.ProviderConfigGroupVersionKind, v1beta1.ProviderConfigUsageGroupVersionKind)
+	return nil
+}
+
+// SetupWebhookWithManager registers the conversion webhook for ProviderConfig.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ProviderConfig{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ProviderConfig")
+	}
 	return nil
 }

--- a/internal/controller/cluster/serviceprincipaldelegated/permissiongrant/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipaldelegated/permissiongrant/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PermissionGrant.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PermissionGrant{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PermissionGrant")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PermissionGrant managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PermissionGrant if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PermissionGrant{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PermissionGrant")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/serviceprincipals/certificate/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipals/certificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Certificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Certificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Certificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/serviceprincipals/claimsmappingpolicyassignment/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipals/claimsmappingpolicyassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for ClaimsMappingPolicyAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicyAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicyAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles ClaimsMappingPolicyAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.ClaimsMappingPolicyAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicyAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicyAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/serviceprincipals/password/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipals/password/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Password.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Password managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Password if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/serviceprincipals/principal/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipals/principal/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Principal.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Principal{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Principal")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Principal managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta2.Principal if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta2.Principal{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Principal")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/serviceprincipals/tokensigningcertificate/zz_controller.go
+++ b/internal/controller/cluster/serviceprincipals/tokensigningcertificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for TokenSigningCertificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.TokenSigningCertificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.TokenSigningCertificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles TokenSigningCertificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.TokenSigningCertificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.TokenSigningCertificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.TokenSigningCertificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/synchronization/job/zz_controller.go
+++ b/internal/controller/cluster/synchronization/job/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Job.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Job{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Job")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Job managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Job if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Job{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Job")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/synchronization/secret/zz_controller.go
+++ b/internal/controller/cluster/synchronization/secret/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Secret.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Secret{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Secret")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Secret managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Secret if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Secret")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/users/user/zz_controller.go
+++ b/internal/controller/cluster/users/user/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for User.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.User{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.User")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles User managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.User if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.User{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.User")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/cluster/zz_setup.go
+++ b/internal/controller/cluster/zz_setup.go
@@ -133,3 +133,47 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 	}
 	return nil
 }
+
+// SetupWebhookWithManager registers conversion webhooks for all resource kinds in the group.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	for _, setup := range []func(ctrl.Manager) error{
+		member.SetupWebhookWithManager,
+		unit.SetupWebhookWithManager,
+		roleassignment.SetupWebhookWithManager,
+		application.SetupWebhookWithManager,
+		approle.SetupWebhookWithManager,
+		certificate.SetupWebhookWithManager,
+		federatedidentitycredential.SetupWebhookWithManager,
+		flexiblefederatedidentitycredential.SetupWebhookWithManager,
+		password.SetupWebhookWithManager,
+		preauthorized.SetupWebhookWithManager,
+		accesspolicy.SetupWebhookWithManager,
+		location.SetupWebhookWithManager,
+		customdirectoryrole.SetupWebhookWithManager,
+		role.SetupWebhookWithManager,
+		roleassignmentdirectoryroles.SetupWebhookWithManager,
+		roleeligibilityschedulerequest.SetupWebhookWithManager,
+		group.SetupWebhookWithManager,
+		membergroups.SetupWebhookWithManager,
+		privilegedaccessgroupassignmentschedule.SetupWebhookWithManager,
+		privilegedaccessgroupeligibilityschedule.SetupWebhookWithManager,
+		invitation.SetupWebhookWithManager,
+		claimsmappingpolicy.SetupWebhookWithManager,
+		grouprolemanagementpolicy.SetupWebhookWithManager,
+		providerconfig.SetupWebhookWithManager,
+		permissiongrant.SetupWebhookWithManager,
+		certificateserviceprincipals.SetupWebhookWithManager,
+		claimsmappingpolicyassignment.SetupWebhookWithManager,
+		passwordserviceprincipals.SetupWebhookWithManager,
+		principal.SetupWebhookWithManager,
+		tokensigningcertificate.SetupWebhookWithManager,
+		job.SetupWebhookWithManager,
+		secret.SetupWebhookWithManager,
+		user.SetupWebhookWithManager,
+	} {
+		if err := setup(mgr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/controller/namespaced/administrativeunits/member/zz_controller.go
+++ b/internal/controller/namespaced/administrativeunits/member/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Member.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Member managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Member if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/administrativeunits/unit/zz_controller.go
+++ b/internal/controller/namespaced/administrativeunits/unit/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Unit.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Unit{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Unit")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Unit managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Unit if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Unit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Unit")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/app/roleassignment/zz_controller.go
+++ b/internal/controller/namespaced/app/roleassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/application/zz_controller.go
+++ b/internal/controller/namespaced/applications/application/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Application.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Application{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Application")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Application managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Application if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Application{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Application")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/approle/zz_controller.go
+++ b/internal/controller/namespaced/applications/approle/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for AppRole.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AppRole{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AppRole")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles AppRole managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.AppRole if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AppRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AppRole")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/certificate/zz_controller.go
+++ b/internal/controller/namespaced/applications/certificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Certificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Certificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Certificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/federatedidentitycredential/zz_controller.go
+++ b/internal/controller/namespaced/applications/federatedidentitycredential/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for FederatedIdentityCredential.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FederatedIdentityCredential{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FederatedIdentityCredential")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles FederatedIdentityCredential managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.FederatedIdentityCredential if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FederatedIdentityCredential{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FederatedIdentityCredential")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/flexiblefederatedidentitycredential/zz_controller.go
+++ b/internal/controller/namespaced/applications/flexiblefederatedidentitycredential/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for FlexibleFederatedIdentityCredential.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FlexibleFederatedIdentityCredential{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FlexibleFederatedIdentityCredential")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles FlexibleFederatedIdentityCredential managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.FlexibleFederatedIdentityCredential if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.FlexibleFederatedIdentityCredential{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.FlexibleFederatedIdentityCredential")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/password/zz_controller.go
+++ b/internal/controller/namespaced/applications/password/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Password.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Password managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Password if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/applications/preauthorized/zz_controller.go
+++ b/internal/controller/namespaced/applications/preauthorized/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PreAuthorized.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PreAuthorized{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PreAuthorized")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PreAuthorized managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PreAuthorized if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PreAuthorized{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PreAuthorized")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/conditionalaccess/accesspolicy/zz_controller.go
+++ b/internal/controller/namespaced/conditionalaccess/accesspolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for AccessPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AccessPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AccessPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles AccessPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.AccessPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.AccessPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.AccessPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/conditionalaccess/location/zz_controller.go
+++ b/internal/controller/namespaced/conditionalaccess/location/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Location.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Location{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Location")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Location managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Location if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Location{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Location")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/directoryroles/customdirectoryrole/zz_controller.go
+++ b/internal/controller/namespaced/directoryroles/customdirectoryrole/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for CustomDirectoryRole.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.CustomDirectoryRole{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.CustomDirectoryRole")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles CustomDirectoryRole managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.CustomDirectoryRole if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.CustomDirectoryRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.CustomDirectoryRole")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/directoryroles/role/zz_controller.go
+++ b/internal/controller/namespaced/directoryroles/role/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Role.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Role{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Role")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Role managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Role if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Role{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Role")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/directoryroles/roleassignment/zz_controller.go
+++ b/internal/controller/namespaced/directoryroles/roleassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/directoryroles/roleeligibilityschedulerequest/zz_controller.go
+++ b/internal/controller/namespaced/directoryroles/roleeligibilityschedulerequest/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for RoleEligibilityScheduleRequest.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleEligibilityScheduleRequest{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleEligibilityScheduleRequest")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles RoleEligibilityScheduleRequest managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.RoleEligibilityScheduleRequest if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.RoleEligibilityScheduleRequest{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.RoleEligibilityScheduleRequest")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/groups/group/zz_controller.go
+++ b/internal/controller/namespaced/groups/group/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Group.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Group{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Group")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Group managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Group if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Group{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Group")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/groups/member/zz_controller.go
+++ b/internal/controller/namespaced/groups/member/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Member.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Member managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Member if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Member{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Member")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/identitygovernance/privilegedaccessgroupassignmentschedule/zz_controller.go
+++ b/internal/controller/namespaced/identitygovernance/privilegedaccessgroupassignmentschedule/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PrivilegedAccessGroupAssignmentSchedule.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupAssignmentSchedule{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PrivilegedAccessGroupAssignmentSchedule managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupAssignmentSchedule{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupAssignmentSchedule")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/identitygovernance/privilegedaccessgroupeligibilityschedule/zz_controller.go
+++ b/internal/controller/namespaced/identitygovernance/privilegedaccessgroupeligibilityschedule/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PrivilegedAccessGroupEligibilitySchedule.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupEligibilitySchedule{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PrivilegedAccessGroupEligibilitySchedule managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PrivilegedAccessGroupEligibilitySchedule{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PrivilegedAccessGroupEligibilitySchedule")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/invitations/invitation/zz_controller.go
+++ b/internal/controller/namespaced/invitations/invitation/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Invitation.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Invitation{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Invitation")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Invitation managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Invitation if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Invitation{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Invitation")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/policies/claimsmappingpolicy/zz_controller.go
+++ b/internal/controller/namespaced/policies/claimsmappingpolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for ClaimsMappingPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles ClaimsMappingPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.ClaimsMappingPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/policies/grouprolemanagementpolicy/zz_controller.go
+++ b/internal/controller/namespaced/policies/grouprolemanagementpolicy/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for GroupRoleManagementPolicy.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.GroupRoleManagementPolicy{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.GroupRoleManagementPolicy")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles GroupRoleManagementPolicy managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.GroupRoleManagementPolicy if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.GroupRoleManagementPolicy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.GroupRoleManagementPolicy")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/providerconfig/config.go
+++ b/internal/controller/namespaced/providerconfig/config.go
@@ -5,6 +5,7 @@
 package providerconfig
 
 import (
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
@@ -69,5 +70,14 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 			mgr.GetLogger().Error(err, "unable to setup reconcilers", "gvk", v1beta1.ClusterProviderConfigGroupVersionKind.String(), "gvk", v1beta1.ProviderConfigGroupVersionKind.String())
 		}
 	}, v1beta1.ClusterProviderConfigGroupVersionKind, v1beta1.ProviderConfigGroupVersionKind, v1beta1.ProviderConfigUsageGroupVersionKind)
+	return nil
+}
+
+// SetupWebhookWithManager registers the conversion webhook for ProviderConfig.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ProviderConfig{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ProviderConfig")
+	}
 	return nil
 }

--- a/internal/controller/namespaced/serviceprincipaldelegated/permissiongrant/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipaldelegated/permissiongrant/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for PermissionGrant.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PermissionGrant{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PermissionGrant")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles PermissionGrant managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.PermissionGrant if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.PermissionGrant{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.PermissionGrant")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/serviceprincipals/certificate/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipals/certificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Certificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Certificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Certificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Certificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Certificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/serviceprincipals/claimsmappingpolicyassignment/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipals/claimsmappingpolicyassignment/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for ClaimsMappingPolicyAssignment.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicyAssignment{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicyAssignment")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles ClaimsMappingPolicyAssignment managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.ClaimsMappingPolicyAssignment if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.ClaimsMappingPolicyAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.ClaimsMappingPolicyAssignment")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/serviceprincipals/password/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipals/password/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Password.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Password managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Password if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Password{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Password")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/serviceprincipals/principal/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipals/principal/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Principal.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Principal{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Principal")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Principal managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Principal if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Principal{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Principal")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/serviceprincipals/tokensigningcertificate/zz_controller.go
+++ b/internal/controller/namespaced/serviceprincipals/tokensigningcertificate/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for TokenSigningCertificate.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.TokenSigningCertificate{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.TokenSigningCertificate")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles TokenSigningCertificate managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.TokenSigningCertificate if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.TokenSigningCertificate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.TokenSigningCertificate")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/synchronization/job/zz_controller.go
+++ b/internal/controller/namespaced/synchronization/job/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Job.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Job{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Job")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Job managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Job if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Job{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Job")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/synchronization/secret/zz_controller.go
+++ b/internal/controller/namespaced/synchronization/secret/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for Secret.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Secret{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Secret")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles Secret managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.Secret if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Secret")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/users/user/zz_controller.go
+++ b/internal/controller/namespaced/users/user/zz_controller.go
@@ -27,6 +27,15 @@ import (
 	features "github.com/upbound/provider-azuread/v2/internal/features"
 )
 
+// SetupWebhookWithManager registers the conversion webhook for User.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.User{}).
+		Complete(); err != nil {
+		return errors.Wrap(err, "cannot register webhook for the kind v1beta1.User")
+	}
+	return nil
+}
+
 // SetupGated adds a controller that reconciles User managed resources.
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
@@ -78,14 +87,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	}
 	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
-	}
-
-	// register webhooks for the kind v1beta1.User if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1beta1.User{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.User")
-		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {

--- a/internal/controller/namespaced/zz_setup.go
+++ b/internal/controller/namespaced/zz_setup.go
@@ -133,3 +133,47 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 	}
 	return nil
 }
+
+// SetupWebhookWithManager registers conversion webhooks for all resource kinds in the group.
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	for _, setup := range []func(ctrl.Manager) error{
+		member.SetupWebhookWithManager,
+		unit.SetupWebhookWithManager,
+		roleassignment.SetupWebhookWithManager,
+		application.SetupWebhookWithManager,
+		approle.SetupWebhookWithManager,
+		certificate.SetupWebhookWithManager,
+		federatedidentitycredential.SetupWebhookWithManager,
+		flexiblefederatedidentitycredential.SetupWebhookWithManager,
+		password.SetupWebhookWithManager,
+		preauthorized.SetupWebhookWithManager,
+		accesspolicy.SetupWebhookWithManager,
+		location.SetupWebhookWithManager,
+		customdirectoryrole.SetupWebhookWithManager,
+		role.SetupWebhookWithManager,
+		roleassignmentdirectoryroles.SetupWebhookWithManager,
+		roleeligibilityschedulerequest.SetupWebhookWithManager,
+		group.SetupWebhookWithManager,
+		membergroups.SetupWebhookWithManager,
+		privilegedaccessgroupassignmentschedule.SetupWebhookWithManager,
+		privilegedaccessgroupeligibilityschedule.SetupWebhookWithManager,
+		invitation.SetupWebhookWithManager,
+		claimsmappingpolicy.SetupWebhookWithManager,
+		grouprolemanagementpolicy.SetupWebhookWithManager,
+		providerconfig.SetupWebhookWithManager,
+		permissiongrant.SetupWebhookWithManager,
+		certificateserviceprincipals.SetupWebhookWithManager,
+		claimsmappingpolicyassignment.SetupWebhookWithManager,
+		passwordserviceprincipals.SetupWebhookWithManager,
+		principal.SetupWebhookWithManager,
+		tokensigningcertificate.SetupWebhookWithManager,
+		job.SetupWebhookWithManager,
+		secret.SetupWebhookWithManager,
+		user.SetupWebhookWithManager,
+	} {
+		if err := setup(mgr); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Related PRs: https://github.com/crossplane-contrib/provider-upjet-aws/pull/2122

Applies the upjet template fix for the conversion webhook / leader election bug  to this provider. It also bumps upjet to `v2.3.0`.

- **`cmd/provider/main.go`**: removes `StartWebhooks` from both opts structs; adds an explicit `startWebhooks` block before the `canSafeStart` gate that calls `SetupWebhookWithManager` for both cluster-scoped and namespaced controllers. A comment at the call site explains why webhook registration must happen here rather than inside the gate.

- **`config/templates/controller.go.tmpl`**: mirrors the upjet template change — adds `SetupWebhookWithManager`, removes the `if o.StartWebhooks { ... }` block from `Setup`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
