### PR TITLE
fix: prefer AZURE_FEDERATED_TOKEN_FILE over hardcoded OIDC token path

### DIFF
--- a/internal/clients/azuread.go
+++ b/internal/clients/azuread.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,8 +55,15 @@ const (
 	keyEnvironment              = "environment"
 	keyOidcTokenFilePath        = "oidc_token_file_path"
 	keyUseOIDC                  = "use_oidc"
-	// Default OidcTokenFilePath
+	// Default OidcTokenFilePath, used only if AZURE_FEDERATED_TOKEN_FILE is
+	// not set and no explicit oidcTokenFilePath is configured. The azure
+	// workload identity webhook owns this path and has changed it before
+	// (see https://github.com/Azure/azure-workload-identity/releases/tag/v1.6.0),
+	// so AZURE_FEDERATED_TOKEN_FILE is the source of truth whenever available.
 	defaultOidcTokenFilePath = "/var/run/secrets/azure/tokens/azure-identity-token"
+	// envAzureFederatedTokenFile is set by the azure workload identity
+	// webhook to the current projected token path.
+	envAzureFederatedTokenFile = "AZURE_FEDERATED_TOKEN_FILE"
 	// Upbound Auth OidcTokenFilePath
 	upboundProviderIdentityTokenFile = "/var/run/secrets/upbound.io/provider/token"
 )
@@ -194,8 +202,14 @@ func oidcAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.Setup)
 	if pcSpec.ClientID == nil || len(*pcSpec.ClientID) == 0 {
 		return errors.New(errClientIDNotSet)
 	}
-	// OIDC Token File Path defaults to a projected-volume path mounted in the pod running in the AKS cluster, when workload identity is enabled on the pod.
+	// OIDC Token File Path: an explicit oidcTokenFilePath always wins. Otherwise
+	// prefer AZURE_FEDERATED_TOKEN_FILE, which the azure workload identity webhook
+	// sets to wherever it actually projected the token, falling back to the
+	// historical hardcoded default only if that env var isn't set.
 	ps.Configuration[keyOidcTokenFilePath] = defaultOidcTokenFilePath
+	if tokenFile := os.Getenv(envAzureFederatedTokenFile); tokenFile != "" {
+		ps.Configuration[keyOidcTokenFilePath] = tokenFile
+	}
 	if pcSpec.OidcTokenFilePath != nil {
 		ps.Configuration[keyOidcTokenFilePath] = *pcSpec.OidcTokenFilePath
 	}

--- a/internal/clients/azuread_test.go
+++ b/internal/clients/azuread_test.go
@@ -7,8 +7,64 @@ package clients
 import (
 	"testing"
 
+	"github.com/crossplane/upjet/v2/pkg/terraform"
 	"github.com/google/go-cmp/cmp"
+
+	namespacedv1beta1 "github.com/upbound/provider-azuread/v2/apis/namespaced/v1beta1"
 )
+
+func Test_oidcAuth_tokenFilePath(t *testing.T) {
+	tenantID, clientID := "tenant", "client"
+	explicitPath := "/explicit/path/azure-identity-token"
+	envPath := "/var/run/secrets/azure/wi/token/azure-identity-token"
+
+	cases := map[string]struct {
+		oidcTokenFilePath *string
+		envValue          string
+		envSet            bool
+		want              string
+	}{
+		"explicit_path_wins_over_env": {
+			oidcTokenFilePath: &explicitPath,
+			envValue:          envPath,
+			envSet:            true,
+			want:              explicitPath,
+		},
+		"env_used_when_no_explicit_path": {
+			envValue: envPath,
+			envSet:   true,
+			want:     envPath,
+		},
+		"falls_back_to_default_when_env_unset": {
+			want: defaultOidcTokenFilePath,
+		},
+		"falls_back_to_default_when_env_empty": {
+			envValue: "",
+			envSet:   true,
+			want:     defaultOidcTokenFilePath,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv(envAzureFederatedTokenFile, tc.envValue)
+			}
+			pcSpec := &namespacedv1beta1.ProviderConfigSpec{
+				TenantID:          &tenantID,
+				ClientID:          &clientID,
+				OidcTokenFilePath: tc.oidcTokenFilePath,
+			}
+			ps := &terraform.Setup{Configuration: terraform.ProviderConfiguration{}}
+			if err := oidcAuth(pcSpec, ps); err != nil {
+				t.Fatalf("oidcAuth() returned unexpected error: %v", err)
+			}
+			got, _ := ps.Configuration[keyOidcTokenFilePath].(string)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("oidc_token_file_path mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func Test_graphServiceFromPath(t *testing.T) {
 	cases := map[string]struct {


### PR DESCRIPTION
## Description of your changes

`oidcAuth()` hardcoded the OIDC token file path to `/var/run/secrets/azure/tokens/azure-identity-token` whenever `oidcTokenFilePath` was left unset on the `ProviderConfig`/`ClusterProviderConfig`. That path is owned and versioned by the AKS `azure-workload-identity` webhook, which moved it as a documented breaking change in v1.6.0:

https://github.com/Azure/azure-workload-identity/releases/tag/v1.6.0

> Never hardcode the token file path. Always read `AZURE_FEDERATED_TOKEN_FILE` — the webhook owns this path and it may change again in future releases.

The webhook already sets `AZURE_FEDERATED_TOKEN_FILE` in the container to wherever it actually projected the token. This change reads that env var when no explicit `oidcTokenFilePath` is configured, and only falls back to the historical hardcoded constant if the env var is also unset (preserving current behavior for anyone relying on it, e.g. clusters still on pre-v1.6.0 webhook builds).

Precedence, in order:
1. `spec.oidcTokenFilePath` if explicitly set (unchanged, still wins).
2. `AZURE_FEDERATED_TOKEN_FILE` env var (new).
3. Hardcoded default path (unchanged fallback).

Fixes #367

The same fix was applied to provider-upjet-azure in [crossplane-contrib/provider-upjet-azure#1281](https://github.com/crossplane-contrib/provider-upjet-azure/pull/1281).

## I have:

- [x] Read and followed Crossplane's [contribution process](https://git.io/crossplane-contributor-guide).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

## How has this code been tested

- Added `Test_oidcAuth_tokenFilePath` covering all four precedence cases (explicit path wins over env, env used when no explicit path, falls back to default when env unset, falls back to default when env set but empty).
- Ran `go build`, `go test ./internal/clients/...` locally.

All pass.